### PR TITLE
Improve Brazilian flag

### DIFF
--- a/src/littlebox.less
+++ b/src/littlebox.less
@@ -2279,6 +2279,7 @@
 	border-left: 2px solid yellow !important;
 	border-right: 2px solid yellow !important;
 	background-color:blue !important;
+  .rotate(45deg);
 }
 
 /*flag-bulgaria littlebox icon*/


### PR DESCRIPTION
Brazilian flag has a yellow rhombus.

Before:
![screen shot 2016-01-09 at 7 52 45 pm](https://cloud.githubusercontent.com/assets/1359344/12218580/9df50910-b70a-11e5-939b-ea44a9215829.png)

After:
![screen shot 2016-01-09 at 7 52 07 pm](https://cloud.githubusercontent.com/assets/1359344/12218584/ac09c266-b70a-11e5-9572-f9728455ab31.png)
